### PR TITLE
Add repo url to Cargo.toml

### DIFF
--- a/recursion/Cargo.toml
+++ b/recursion/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 edition = "2021"
 description = "cache-aware stack safe recursion"
 license = "MIT OR Apache-2.0"
-
+repository = "https://github.com/inanna-malick/recursion"
 
 [features]
 default = []


### PR DESCRIPTION
Hey I was reading your blog posts about recursion algorithms and noticed that this package on crates.io doesn't link to this repository, which made it somewhat harder to find. I think publishing with this in the toml fixes that